### PR TITLE
Key Aliasing causing tracker issues

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,15 @@
+Alias keys are not getting the correct limits
+its because the limits are imposed by keyUUID
+which is unique to each alias.
+We need to scope limits to the datascope to
+enforce limits on all items.
+
+- Identify where we create keys initially and ensure that we set the scopes correcrlyt off-cuff for root
+
+- when set limits with --root comes in we can set via alias as its the same data ascope
+
+- when get limits comes in on an alias, give the
+limits that are imposed at the datascope level
+
+Updating limits has to happen on the root key 
+

--- a/cluster.yaml
+++ b/cluster.yaml
@@ -6,12 +6,12 @@ rootPrefix: "some-secure-prefix"
 defaultLeader: "node0"
 
 # Directory for storing insi data
-insiHome: "/home/bosley/.config/insi"
+insiHome: "/Users/bosley/.config/insi"
 
 # TLS will be in same spot on all nodes
 tls:
-  cert: /home/bosley/.config/insi/keys/server.crt
-  key: /home/bosley/.config/insi/keys/server.key
+  cert: /Users/bosley/.config/insi/keys/server.crt
+  key: /Users/bosley/.config/insi/keys/server.key
 
 clientSkipVerify: true
 serverMustUseTLS: true

--- a/db/core/blob.go
+++ b/db/core/blob.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -283,7 +284,7 @@ func (x *blobService) downloadBlobFromPeer(ctx context.Context, blobMeta models.
 	}
 
 	downloadURL := fmt.Sprintf("https://%s/db/internal/v1/blob/download?key=%s&scope=%s",
-		net.JoinHostPort(connectHost, port), blobMeta.Key, blobMeta.DataScopeUUID)
+		net.JoinHostPort(connectHost, port), url.QueryEscape(blobMeta.Key), url.QueryEscape(blobMeta.DataScopeUUID))
 
 	req, err := http.NewRequestWithContext(
 		ctx,

--- a/db/core/blob.go
+++ b/db/core/blob.go
@@ -460,7 +460,7 @@ func (c *Core) uploadBlobHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeData) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeData) {
 		return
 	}
 
@@ -659,7 +659,7 @@ func (c *Core) getBlobHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeData) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeData) {
 		return
 	}
 
@@ -701,7 +701,7 @@ func (c *Core) deleteBlobHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeData) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeData) {
 		return
 	}
 
@@ -772,7 +772,7 @@ func (c *Core) iterateBlobKeysByPrefixHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeData) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeData) {
 		return
 	}
 

--- a/db/core/cache.go
+++ b/db/core/cache.go
@@ -25,7 +25,7 @@ func (c *Core) getCacheHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeData) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeData) {
 		return
 	}
 
@@ -66,7 +66,7 @@ func (c *Core) setCacheHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeData) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeData) {
 		return
 	}
 
@@ -162,7 +162,7 @@ func (c *Core) deleteCacheHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeData) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeData) {
 		return
 	}
 
@@ -234,7 +234,7 @@ func (c *Core) setCacheNXHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeData) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeData) {
 		return
 	}
 
@@ -308,7 +308,7 @@ func (c *Core) compareAndSwapCacheHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeData) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeData) {
 		return
 	}
 
@@ -420,7 +420,7 @@ func (c *Core) iterateCacheKeysByPrefixHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeData) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeData) {
 		return
 	}
 

--- a/db/core/events.go
+++ b/db/core/events.go
@@ -300,7 +300,7 @@ func (c *Core) registerSubscriber(session *eventSession) {
 	defer c.wsConnectionLock.Unlock()
 
 	if c.activeWsConnections >= int32(c.cfg.Sessions.MaxConnections) {
-		c.logger.Error("Attempted to register subscriber when max connections already met or exceeded, releasing slot", "active", c.activeWsConnections, "max", c.cfg.Sessions.MaxConnections, "key_uuid", session.keyUUID)
+		c.logger.Error("Attempted to register subscriber when max connections already met or exceeded, releasing slot", "active", c.activeWsConnections, "max", c.cfg.Sessions.MaxConnections, "key_uuid", session.td.KeyUUID, "ds", session.td.DataScopeUUID)
 		go session.conn.Close()
 		c.releaseSubscriptionSlot(session.td.DataScopeUUID)
 		return

--- a/db/core/events.go
+++ b/db/core/events.go
@@ -694,13 +694,7 @@ type subscriptionSlotRequest struct {
 
 func (c *Core) getSubscriptionUsage(dataScopeUUID string) (limit, current int64, err error) {
 
-	// get datascope for key uuid
-	dsUUID, err := c.fsm.Get(withApiKeyDataScope(dataScopeUUID))
-	if err != nil {
-		return 0, 0, fmt.Errorf("could not get data scope: %w", err)
-	}
-
-	limitStr, err := c.fsm.Get(WithApiKeyMaxSubscriptions(dsUUID))
+	limitStr, err := c.fsm.Get(WithApiKeyMaxSubscriptions(dataScopeUUID))
 	if err != nil {
 		return 0, 0, fmt.Errorf("could not get max subscribers limit: %w", err)
 	}
@@ -709,7 +703,7 @@ func (c *Core) getSubscriptionUsage(dataScopeUUID string) (limit, current int64,
 		return 0, 0, fmt.Errorf("could not parse max subscribers limit: %w", err)
 	}
 
-	currentSubsStr, err := c.fsm.Get(WithApiKeySubscriptions(dsUUID))
+	currentSubsStr, err := c.fsm.Get(WithApiKeySubscriptions(dataScopeUUID))
 	if err != nil && !tkv.IsErrKeyNotFound(err) {
 		return 0, 0, fmt.Errorf("could not get current subscribers: %w", err)
 	}

--- a/db/core/events.go
+++ b/db/core/events.go
@@ -225,7 +225,7 @@ func (c *Core) eventSubscribeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeEvents) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeEvents) {
 		return
 	}
 
@@ -553,7 +553,7 @@ func (c *Core) eventsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeEvents) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeEvents) {
 		return
 	}
 
@@ -724,7 +724,7 @@ func (c *Core) eventPurgeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeEvents) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeEvents) {
 		return
 	}
 

--- a/db/core/insight.go
+++ b/db/core/insight.go
@@ -70,14 +70,14 @@ func (c *Core) getEntity(keyUUID, apiKey, dataScopeUUID string) (models.Entity, 
 		return &val
 	}
 
-	usage.CurrentUsage.BytesInMemory = getUsagePtr(WithApiKeyMemoryUsage(keyUUID), 0)
-	usage.MaxLimits.BytesInMemory = getUsagePtr(WithApiKeyMaxMemoryUsage(keyUUID), ApiDefaultMaxMemoryUsage)
-	usage.CurrentUsage.BytesOnDisk = getUsagePtr(WithApiKeyDiskUsage(keyUUID), 0)
-	usage.MaxLimits.BytesOnDisk = getUsagePtr(WithApiKeyMaxDiskUsage(keyUUID), ApiDefaultMaxDiskUsage)
-	usage.CurrentUsage.EventsEmitted = getUsagePtr(WithApiKeyEvents(keyUUID), 0)
-	usage.MaxLimits.EventsEmitted = getUsagePtr(WithApiKeyMaxEvents(keyUUID), ApiDefaultMaxEvents)
-	usage.CurrentUsage.Subscribers = getUsagePtr(WithApiKeySubscriptions(keyUUID), 0)
-	usage.MaxLimits.Subscribers = getUsagePtr(WithApiKeyMaxSubscriptions(keyUUID), ApiDefaultMaxSubscriptions)
+	usage.CurrentUsage.BytesInMemory = getUsagePtr(WithApiKeyMemoryUsage(dataScopeUUID), 0)
+	usage.MaxLimits.BytesInMemory = getUsagePtr(WithApiKeyMaxMemoryUsage(dataScopeUUID), ApiDefaultMaxMemoryUsage)
+	usage.CurrentUsage.BytesOnDisk = getUsagePtr(WithApiKeyDiskUsage(dataScopeUUID), 0)
+	usage.MaxLimits.BytesOnDisk = getUsagePtr(WithApiKeyMaxDiskUsage(dataScopeUUID), ApiDefaultMaxDiskUsage)
+	usage.CurrentUsage.EventsEmitted = getUsagePtr(WithApiKeyEvents(dataScopeUUID), 0)
+	usage.MaxLimits.EventsEmitted = getUsagePtr(WithApiKeyMaxEvents(dataScopeUUID), ApiDefaultMaxEvents)
+	usage.CurrentUsage.Subscribers = getUsagePtr(WithApiKeySubscriptions(dataScopeUUID), 0)
+	usage.MaxLimits.Subscribers = getUsagePtr(WithApiKeyMaxSubscriptions(dataScopeUUID), ApiDefaultMaxSubscriptions)
 
 	entity := models.Entity{
 		RootApiKey:    apiKey,

--- a/db/core/insight.go
+++ b/db/core/insight.go
@@ -106,14 +106,16 @@ func (c *Core) GetEntity(rootApiKey string) (models.Entity, error) {
 }
 
 func (c *Core) GetEntities(offset, limit int) ([]models.Entity, error) {
-	keys, err := c.fsm.Iterate(ApiTrackMemoryPrefix, offset, limit, "")
+
+	// Use the apiKeyRefPrefix to get the actual Key UUID. Others use data scope uuid which can not be mapped back to a key.
+	keys, err := c.fsm.Iterate(apiKeyRefPrefix, offset, limit, "")
 	if err != nil {
 		return nil, err
 	}
 
 	var entities []models.Entity
 	for _, key := range keys {
-		keyUUID := strings.TrimPrefix(key, ApiTrackMemoryPrefix+":")
+		keyUUID := strings.TrimPrefix(key, apiKeyRefPrefix+":")
 		entity, err := c.GetEntityByKeyUUID(keyUUID)
 		if err != nil {
 			c.logger.Warn("could not get entity for key uuid during iteration", "key_uuid", keyUUID, "error", err)

--- a/db/core/system.go
+++ b/db/core/system.go
@@ -661,7 +661,7 @@ func (c *Core) callerLimitsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the limit for disk usage
-	diskLimitForKey, err := c.fsm.Get(WithApiKeyMaxDiskUsage(td.KeyUUID))
+	diskLimitForKey, err := c.fsm.Get(WithApiKeyMaxDiskUsage(td.DataScopeUUID))
 	if err != nil {
 		c.logger.Error("Could not get limit for disk usage", "error", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -674,7 +674,7 @@ func (c *Core) callerLimitsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	memLimitForKey, err := c.fsm.Get(WithApiKeyMaxMemoryUsage(td.KeyUUID))
+	memLimitForKey, err := c.fsm.Get(WithApiKeyMaxMemoryUsage(td.DataScopeUUID))
 	if err != nil {
 		c.logger.Error("Could not get limit for memory usage", "error", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -687,7 +687,7 @@ func (c *Core) callerLimitsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	eventsLimitForKey, err := c.fsm.Get(WithApiKeyMaxEvents(td.KeyUUID))
+	eventsLimitForKey, err := c.fsm.Get(WithApiKeyMaxEvents(td.DataScopeUUID))
 	if err != nil {
 		c.logger.Error("Could not get limit for events usage", "error", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -700,7 +700,7 @@ func (c *Core) callerLimitsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	subscribersLimitForKey, err := c.fsm.Get(WithApiKeyMaxSubscriptions(td.KeyUUID))
+	subscribersLimitForKey, err := c.fsm.Get(WithApiKeyMaxSubscriptions(td.DataScopeUUID))
 	if err != nil {
 		c.logger.Error("Could not get limit for subscribers usage", "error", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -714,7 +714,7 @@ func (c *Core) callerLimitsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the current usage for disk
-	diskUsage, err := c.fsm.Get(WithApiKeyDiskUsage(td.KeyUUID))
+	diskUsage, err := c.fsm.Get(WithApiKeyDiskUsage(td.DataScopeUUID))
 	if err != nil {
 		c.logger.Error("Could not get current disk usage", "error", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -728,7 +728,7 @@ func (c *Core) callerLimitsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the current usage for memory
-	memUsage, err := c.fsm.Get(WithApiKeyMemoryUsage(td.KeyUUID))
+	memUsage, err := c.fsm.Get(WithApiKeyMemoryUsage(td.DataScopeUUID))
 	if err != nil {
 		c.logger.Error("Could not get current memory usage", "error", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -742,7 +742,7 @@ func (c *Core) callerLimitsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the current usage for events
-	eventsUsage, err := c.fsm.Get(WithApiKeyEvents(td.KeyUUID))
+	eventsUsage, err := c.fsm.Get(WithApiKeyEvents(td.DataScopeUUID))
 	if err != nil {
 		c.logger.Error("Could not get current events usage", "error", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -756,7 +756,7 @@ func (c *Core) callerLimitsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the current usage for subscribers
-	subscribersUsage, err := c.fsm.Get(WithApiKeySubscriptions(td.KeyUUID))
+	subscribersUsage, err := c.fsm.Get(WithApiKeySubscriptions(td.DataScopeUUID))
 	if err != nil {
 		c.logger.Error("Could not get current subscribers usage", "error", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -769,7 +769,7 @@ func (c *Core) callerLimitsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rpsDataLimitForKey, err := c.fsm.Get(WithApiKeyRPSDataLimit(td.KeyUUID))
+	rpsDataLimitForKey, err := c.fsm.Get(WithApiKeyRPSDataLimit(td.DataScopeUUID))
 	if err != nil {
 		c.logger.Error("Could not get current RPS data limit", "error", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -783,7 +783,7 @@ func (c *Core) callerLimitsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rpsEventLimitForKey, err := c.fsm.Get(WithApiKeyRPSEventLimit(td.KeyUUID))
+	rpsEventLimitForKey, err := c.fsm.Get(WithApiKeyRPSEventLimit(td.DataScopeUUID))
 	if err != nil {
 		c.logger.Error("Could not get current RPS event limit", "error", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/db/core/system.go
+++ b/db/core/system.go
@@ -966,7 +966,7 @@ func (c *Core) specificLimitsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Ensure theres no tombstone (deleted key)
-	tombstoneKey := WithApiKeyTombstone(td.DataScopeUUID)
+	tombstoneKey := WithApiKeyTombstone(td.KeyUUID)
 	_, err = c.fsm.Get(tombstoneKey)
 	if err == nil {
 		c.logger.Error("Tombstone found for key (marked for deletion)", "key", td.KeyUUID)
@@ -983,7 +983,7 @@ func (c *Core) specificLimitsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if the key exists before proceeding.
-	fsmStorageKey := fmt.Sprintf("%s:api:key:%s", c.cfg.RootPrefix, td.DataScopeUUID)
+	fsmStorageKey := fmt.Sprintf("%s:api:key:%s", c.cfg.RootPrefix, td.KeyUUID)
 	if _, err := c.fsm.Get(fsmStorageKey); err != nil {
 		c.logger.Warn("Attempt to get limits for non-existent API key", "key_uuid", td.KeyUUID, "error", err)
 		w.Header().Set("Content-Type", "application/json")

--- a/db/core/values.go
+++ b/db/core/values.go
@@ -26,7 +26,7 @@ func (c *Core) getHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeData) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeData) {
 		return
 	}
 
@@ -68,7 +68,7 @@ func (c *Core) iterateKeysByPrefixHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeData) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeData) {
 		return
 	}
 
@@ -140,7 +140,7 @@ func (c *Core) setHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeData) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeData) {
 		return
 	}
 
@@ -234,7 +234,7 @@ func (c *Core) deleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeData) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeData) {
 		return
 	}
 
@@ -307,7 +307,7 @@ func (c *Core) setNXHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeData) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeData) {
 		return
 	}
 
@@ -384,7 +384,7 @@ func (c *Core) compareAndSwapHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeData) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeData) {
 		return
 	}
 
@@ -479,7 +479,7 @@ func (c *Core) bumpHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.CheckRateLimit(w, r, td.KeyUUID, limiterTypeData) {
+	if !c.CheckRateLimit(w, r, td, limiterTypeData) {
 		return
 	}
 

--- a/fwi/fwi.go
+++ b/fwi/fwi.go
@@ -833,6 +833,12 @@ func (f *fwiImpl) UpdateEntityLimits(
 	if newLimits.Subscribers != nil {
 		mergedLimits.Subscribers = newLimits.Subscribers
 	}
+	if newLimits.RPSEventLimit != nil {
+		mergedLimits.RPSEventLimit = newLimits.RPSEventLimit
+	}
+	if newLimits.RPSDataLimit != nil {
+		mergedLimits.RPSDataLimit = newLimits.RPSDataLimit
+	}
 
 	// Validate the merged limits.
 	if mergedLimits.BytesInMemory != nil && mergedLimits.BytesOnDisk != nil {

--- a/fwi/fwi.go
+++ b/fwi/fwi.go
@@ -629,6 +629,16 @@ func (f *fwiImpl) CreateEntity(
 		*maxlimits.Subscribers = 100
 	}
 
+	if maxlimits.RPSDataLimit == nil {
+		maxlimits.RPSDataLimit = new(int64)
+		*maxlimits.RPSDataLimit = models.DefaultRPSDataLimit
+	}
+
+	if maxlimits.RPSEventLimit == nil {
+		maxlimits.RPSEventLimit = new(int64)
+		*maxlimits.RPSEventLimit = models.DefaultRPSEventLimit
+	}
+
 	// set the limits on the entity key
 	if err := withRetriesVoid(ctx, f.logger, func() error {
 		return f.rootInsiClient.SetLimits(key.Key, maxlimits)


### PR DESCRIPTION
When I initially made the key aliasing I guess I goofed and made it such that all aliases wen't to the default limiters when created. This was because we were scoping the access at the key UUID level, which is unique per key/alias. They share a data scope UUID that marks their collective access region. 

This update addresses the limiting issues described, ensuring that limits are imposed at the data-scope level, rather than the specific key level. 

This cascaded to affecting trackers so I streamlined the interaction there.

During manual testing I noticed a hidden feature where blobs with spaces in the name were being ingested by one node only and then causing a breaking update cycle as the internal routing that transfers blobs between nodes neglected to url encode the key (wtf I remember doing this, but w/e) 

I ran all tests and tested by hand using a insi-top web auth host that utilizes the entity framework for user isolation (testing in prod.)