### PR TITLE
Event shaking

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -531,11 +531,10 @@ func (c *Client) doRequest(method, path string, queryParams map[string]string, b
 
 			if resp.StatusCode == http.StatusTemporaryRedirect || resp.StatusCode == http.StatusPermanentRedirect {
 				c.redirectCoutner.Add(1)
-				// This is a leader redirect. Update the client to stick to the new leader for future requests.
 				if c.enableLeaderStickiness {
 					if err := c.setLeader(redirectURL); err != nil {
-						// Log the error but continue; the redirect will be handled for this single request anyway.
-						c.logger.Warn("Failed to set sticky leader from redirect", "error", err)
+						c.logger.Warn(
+							"Failed to set sticky leader from redirect", "error", err, "url", redirectURL.String())
 					}
 				}
 			}

--- a/client/client.go
+++ b/client/client.go
@@ -1353,6 +1353,25 @@ func (c *Client) SubscribeToEvents(topic string, ctx context.Context, onEvent fu
 	}
 }
 
+// ShakeEventSubscriptions disconnects all event subscriptions and force sets the subscription count to 0.
+func (c *Client) ShakeEventSubscriptions() (int, error) {
+	var response struct {
+		Success              bool `json:"success"`
+		DisconnectedSessions int  `json:"disconnected_sessions"`
+	}
+
+	err := c.doRequest(http.MethodPost, "db/api/v1/events/shake", nil, nil, &response)
+	if err != nil {
+		return 0, err
+	}
+
+	if !response.Success {
+		return 0, fmt.Errorf("shake operation reported failure")
+	}
+
+	return response.DisconnectedSessions, nil
+}
+
 // PurgeEventSubscriptions disconnects all event subscriptions for the current API key.
 // Returns the number of disconnected sessions.
 func (c *Client) PurgeEventSubscriptions() (int, error) {

--- a/cmd/insic/main.go
+++ b/cmd/insic/main.go
@@ -311,6 +311,8 @@ func main() {
 		handleSubscribe(cli, cmdArgs)
 	case "purge":
 		handlePurge(cli, cmdArgs)
+	case "shake":
+		handleShake(cli, cmdArgs)
 	case "api":
 		handleApi(cli, cmdArgs)
 	case "blob":
@@ -361,6 +363,7 @@ func printUsage() {
 	fmt.Fprintf(os.Stderr, "  %s %s %s\n", color.GreenString("publish"), color.CyanString("<topic>"), color.CyanString("<data>"))
 	fmt.Fprintf(os.Stderr, "  %s %s\n", color.GreenString("subscribe"), color.CyanString("<topic>"))
 	fmt.Fprintf(os.Stderr, "  %s %s\n", color.GreenString("purge"), color.YellowString("Disconnect all event subscriptions for current API key"))
+	fmt.Fprintf(os.Stderr, "  %s %s\n", color.GreenString("shake"), color.YellowString("Force disconnect all event subscriptions and reset counters"))
 
 	// API Key Commands (Note: These typically require the --root flag)
 	fmt.Fprintf(os.Stderr, "  %s %s %s %s\n", color.GreenString("api"), color.CyanString("add"), color.CyanString("<key_name>"), color.YellowString("--root flag required"))
@@ -492,6 +495,29 @@ func handlePurge(c *client.Client, args []string) {
 		color.HiYellow("No active event subscriptions found to purge.")
 	} else {
 		color.HiGreen("Successfully purged %d event subscription(s).", disconnectedCount)
+	}
+}
+
+func handleShake(c *client.Client, args []string) {
+	if len(args) != 0 {
+		logger.Error("shake: does not take arguments")
+		printUsage()
+		os.Exit(1)
+	}
+
+	logger.Info("Attempting to shake all event subscriptions for current API key")
+
+	disconnectedCount, err := c.ShakeEventSubscriptions()
+	if err != nil {
+		logger.Error("Shake failed", "error", err)
+		fmt.Fprintf(os.Stderr, "%s %s\n", color.RedString("Error:"), err)
+		os.Exit(1)
+	}
+
+	if disconnectedCount == 0 {
+		color.HiYellow("No active event subscriptions found to shake.")
+	} else {
+		color.HiGreen("Successfully shook %d event subscription(s) and reset counters.", disconnectedCount)
 	}
 }
 

--- a/db/core/core.go
+++ b/db/core/core.go
@@ -545,6 +545,7 @@ func (c *Core) Run() {
 		c.pubMux.Handle("/db/api/v1/events", c.ipPublicFilterMiddleware()(c.rateLimitMiddleware(http.HandlerFunc(c.eventsHandler), "events")))
 		c.pubMux.Handle("/db/api/v1/events/subscribe", c.ipPublicFilterMiddleware()(c.rateLimitMiddleware(http.HandlerFunc(c.eventSubscribeHandler), "events")))
 		c.pubMux.Handle("/db/api/v1/events/purge", c.ipPublicFilterMiddleware()(c.rateLimitMiddleware(http.HandlerFunc(c.eventPurgeHandler), "events")))
+		c.pubMux.Handle("/db/api/v1/events/shake", c.ipPublicFilterMiddleware()(c.rateLimitMiddleware(http.HandlerFunc(c.eventShakeHandler), "events")))
 
 		c.pubMux.Handle("/db/api/v1/ping", c.ipPublicFilterMiddleware()(c.rateLimitMiddleware(http.HandlerFunc(c.authedPing), "system")))
 

--- a/db/core/system.go
+++ b/db/core/system.go
@@ -671,6 +671,7 @@ func (c *Core) ValidateToken(r *http.Request, rootOnly AccessEntity) (models.Tok
 			Entity:        EntityRoot,
 			DataScopeUUID: c.cfg.RootPrefix,
 			KeyUUID:       c.cfg.RootPrefix,
+			Token:         token,
 		}, true
 	}
 
@@ -706,6 +707,7 @@ func (c *Core) ValidateToken(r *http.Request, rootOnly AccessEntity) (models.Tok
 			finalTd := rootTdFromFsm
 			finalTd.Entity = td.Entity // Keep alias entity name
 			finalTd.IsAlias = true     // Mark that auth was via an alias
+			finalTd.Token = token
 
 			c.apiCache.Set(token, finalTd, c.cfg.Cache.Keys)
 			return finalTd, true

--- a/db/models/apikey.go
+++ b/db/models/apikey.go
@@ -23,6 +23,7 @@ type TokenData struct {
 	DataScopeUUID string `json:"ds"`
 	KeyUUID       string `json:"k"`
 	IsAlias       bool   `json:"is_alias,omitempty"`
+	Token         string `json:"-"` // The raw token string
 }
 
 type Limits struct {


### PR DESCRIPTION
The eventing system that load-balances subscriptions to nodes is great but in the cosmic chance one of the nodes crashes hard due to hardware failure or rug pulling the event subscription limitation mechanism can not be reset

I would like to eventually upgrade the core event service to monitor actively for this, but since its such a one-off thing that I can only get to happen if I try I figured for now I would add the "shake" command to the server and client so we can fix it if it_actually_ occurs and then only if it happens in practice will I take the time to write the module

Shake is essentially the same thing as an iterative `events purge` from insic, but it locks the caller's subscription slots and then shakes everyone tied to their subscription system off before forcing the subscriber count to `0`. 

This means that while running no subscribers can subscribe to a topic for that tenant to ensure that the reset occurs correctly 

Again, this is for an edge case I found and I suspect it won't be an issue unless I just yoink the plug on a server while its hosting someones subs